### PR TITLE
feature: final debt constants

### DIFF
--- a/packages/lib-base/src/constants.ts
+++ b/packages/lib-base/src/constants.ts
@@ -19,7 +19,7 @@ export const MINIMUM_COLLATERAL_RATIO = Decimal.from(1.1);
  *
  * @public
  */
-export const HCHF_LIQUIDATION_RESERVE = Decimal.from(1);
+export const HCHF_LIQUIDATION_RESERVE = Decimal.from(20);
 
 /**
  * A Trove must always have at least this much debt on top of the
@@ -30,7 +30,7 @@ export const HCHF_LIQUIDATION_RESERVE = Decimal.from(1);
  *
  * @public
  */
-export const HCHF_MINIMUM_NET_DEBT = Decimal.from(1);
+export const HCHF_MINIMUM_NET_DEBT = Decimal.from(1780);
 
 /**
  * A Trove must always have at least this much debt.


### PR DESCRIPTION
currently breaks operation on existing troves that have < 20 hchf net debt.