### PR TITLE
fix: 🐛 catch errors that happen during store refresh

### DIFF
--- a/packages/lib-ethers/src/BlockPolledLiquityStore.ts
+++ b/packages/lib-ethers/src/BlockPolledLiquityStore.ts
@@ -296,16 +296,20 @@ export class BlockPolledLiquityStore extends HLiquityStore<BlockPolledLiquitySto
   }
 
   public async refresh(): Promise<LiquityStoreState<BlockPolledLiquityStoreExtraState>> {
-    const state = await this._get();
+    try {
+      const state = await this._get();
 
-    if (this._loaded) {
-      this._update(...state);
+      if (this._loaded) {
+        this._update(...state);
 
-      return this.state;
-    } else {
+        return this.state;
+      }
       this._load(...state);
-      return this.state;
+    } catch (throwable) {
+      console.warn(`unable to update the store`, throwable);
     }
+
+    return this.state;
   }
 
   /** @internal @override */

--- a/packages/lib-hashgraph/src/HashgraphLiquity.ts
+++ b/packages/lib-hashgraph/src/HashgraphLiquity.ts
@@ -558,15 +558,19 @@ export class HashgraphLiquity
   }
 
   async refresh(): Promise<LiquityStoreState<HashgraphLiquityStoreState>> {
-    const stateUpdates = await this.fetchStoreValues()
+    try {
+      const stateUpdates = await this.fetchStoreValues()
 
-    if (this._loaded) {
-      this._update(...stateUpdates)
+      if (this._loaded) {
+        this._update(...stateUpdates)
 
-      return this.state
+        return this.state
+      }
+
+      this._load(...stateUpdates)
+    } catch (throwable) {
+      console.warn(`unable to update the store`, throwable)
     }
-
-    this._load(...stateUpdates)
 
     return this.state
   }


### PR DESCRIPTION
outdated store > error due to unreliable rpc